### PR TITLE
feat: Apply Minimalist Tech Style to UI

### DIFF
--- a/webapp/static/css/minimal_tech.css
+++ b/webapp/static/css/minimal_tech.css
@@ -1,0 +1,205 @@
+:root {
+    /* Minimalist Tech Style - Color Palette (Dark Theme) */
+    --tech-bg-color: #121212;
+    --tech-surface-color: #1E1E1E;
+    --tech-text-primary-color: #E0E0E0;
+    --tech-text-secondary-color: #A0A0A0;
+    --tech-accent-color: #03DAC6;
+    --tech-error-color: #CF6679;
+    --tech-border-color: #383838;
+
+    /* Base Typography */
+    --tech-font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+body.mdc-typography {
+    font-family: var(--tech-font-family);
+    background-color: var(--tech-bg-color);
+    color: var(--tech-text-primary-color);
+    margin: 0;
+
+    background-image:
+        linear-gradient(to right, rgba(200, 200, 200, 0.03) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(200, 200, 200, 0.03) 1px, transparent 1px);
+    background-size: 20px 20px;
+}
+
+.page-content-wrapper {
+    padding: 24px; /* Increased from 16px */
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.mdc-card {
+    background-color: var(--tech-surface-color);
+    border-radius: 4px;
+    border: 1px solid var(--tech-border-color);
+    box-shadow: none;
+}
+
+.card-content-wrapper {
+    padding: 32px; /* Increased from 24px */
+    color: var(--tech-text-primary-color);
+}
+
+.card-content-wrapper h1.mdc-typography--headline4 {
+    color: var(--tech-text-primary-color);
+    text-align: center;
+    margin-bottom: 40px; /* Increased from 32px */
+    font-weight: 600;
+}
+
+.form-field-wrapper {
+    width: 100%;
+    margin-bottom: 24px; /* Increased from 16px */
+}
+
+/* --- MDC Text Field Refinements --- */
+.mdc-text-field--outlined {
+    --mdc-theme-primary: var(--tech-accent-color);
+    border-radius: 4px;
+}
+
+.mdc-text-field--outlined .mdc-notched-outline__leading,
+.mdc-text-field--outlined .mdc-notched-outline__notch,
+.mdc-text-field--outlined .mdc-notched-outline__trailing {
+    border-color: var(--tech-border-color);
+}
+
+.mdc-text-field--outlined.mdc-text-field--focused .mdc-notched-outline__leading,
+.mdc-text-field--outlined.mdc-text-field--focused .mdc-notched-outline__notch,
+.mdc-text-field--outlined.mdc-text-field--focused .mdc-notched-outline__trailing {
+    border-color: var(--tech-accent-color);
+    border-width: 2px;
+}
+
+.mdc-text-field--outlined .mdc-text-field__input {
+    color: var(--tech-text-primary-color);
+}
+
+.mdc-text-field--outlined .mdc-floating-label {
+    color: var(--tech-text-secondary-color);
+}
+
+.mdc-text-field--outlined.mdc-text-field--focused .mdc-floating-label,
+.mdc-text-field--outlined .mdc-floating-label--float-above {
+    color: var(--tech-accent-color);
+}
+
+
+/* --- MDC Select Refinements --- */
+.mdc-select--outlined {
+    --mdc-theme-primary: var(--tech-accent-color);
+    border-radius: 4px;
+}
+
+.mdc-select--outlined .mdc-notched-outline__leading,
+.mdc-select--outlined .mdc-notched-outline__notch,
+.mdc-select--outlined .mdc-notched-outline__trailing {
+    border-color: var(--tech-border-color);
+}
+
+.mdc-select--outlined.mdc-select--focused .mdc-notched-outline__leading,
+.mdc-select--outlined.mdc-select--focused .mdc-notched-outline__notch,
+.mdc-select--outlined.mdc-select--focused .mdc-notched-outline__trailing {
+    border-color: var(--tech-accent-color);
+    border-width: 2px;
+}
+
+.mdc-select--outlined .mdc-select__selected-text {
+    color: var(--tech-text-primary-color);
+}
+
+.mdc-select--outlined .mdc-floating-label {
+    color: var(--tech-text-secondary-color);
+}
+
+.mdc-select--outlined.mdc-select--focused .mdc-floating-label,
+.mdc-select--outlined .mdc-floating-label--float-above {
+    color: var(--tech-accent-color);
+}
+
+.mdc-menu-surface.mdc-select__menu {
+    background-color: var(--tech-surface-color);
+    border: 1px solid var(--tech-border-color);
+    border-radius: 4px;
+}
+
+.mdc-list-item .mdc-list-item__text {
+    color: var(--tech-text-primary-color);
+}
+
+.mdc-list-item--selected .mdc-list-item__text {
+    color: var(--tech-accent-color);
+}
+
+.mdc-list-item:hover .mdc-list-item__text {
+    color: var(--tech-accent-color);
+}
+.mdc-list-item--selected:hover .mdc-list-item__text {
+    color: var(--tech-accent-color);
+}
+
+
+.mdc-select__dropdown-icon-graphic .mdc-select__dropdown-icon-inactive,
+.mdc-select__dropdown-icon-graphic .mdc-select__dropdown-icon-active {
+    fill: var(--tech-text-secondary-color);
+}
+
+/* --- MDC Button Refinements --- */
+.form-actions-wrapper {
+    margin-top: 32px;  /* Added margin-top */
+    margin-bottom: 16px;
+    text-align: center;
+}
+
+.mdc-button--raised {
+    background-color: var(--tech-accent-color);
+    color: var(--tech-bg-color);
+    border-radius: 4px;
+    box-shadow: none;
+    border: 1px solid var(--tech-accent-color);
+}
+
+.mdc-button--raised:hover, .mdc-button--raised:focus {
+    background-color: color-mix(in srgb, var(--tech-accent-color) 90%, #ffffff);
+    box-shadow: none;
+    border-color: color-mix(in srgb, var(--tech-accent-color) 90%, #ffffff);
+    color: var(--tech-bg-color);
+}
+
+.mdc-button--raised .mdc-button__label {
+   /* color: var(--tech-bg-color); Is inherited */
+}
+
+
+/* --- Result Area --- */
+#result_sql_container {
+    margin-top: 40px; /* Increased from 24px */
+}
+
+#result_sql_container h2.mdc-typography--headline6 {
+    color: var(--tech-text-primary-color);
+    margin-bottom: 16px; /* Increased from 12px */
+    font-weight: 500;
+}
+
+pre#result_sql {
+    border: 1px solid var(--tech-border-color);
+    padding: 20px; /* Increased from 16px */
+    border-radius: 4px;
+    min-height: 120px; /* Increased from 100px */
+    background-color: var(--tech-bg-color);
+    color: var(--tech-text-secondary-color);
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+}
+
+p#error_message.mdc-typography--caption {
+    color: var(--tech-error-color);
+    margin-top: 12px; /* Increased from 8px */
+    min-height: 1.2em; /* Ensure space even when empty */
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -6,16 +6,17 @@
     <title>Math2SQL</title>
     <!-- Material Components Web CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-components-web/14.0.0/material-components-web.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/minimal_tech.css') }}">
 </head>
 <body class="mdc-typography">
     <main class="container">
-        <div style="padding: 16px;">
+        <div class="page-content-wrapper">
             <div class="mdc-card">
-                <div style="padding: 16px;"> <!-- Added padding around card content -->
-                    <h1 class="mdc-typography--headline4" style="text-align: center; margin-bottom: 24px;">数学公式转 SQL</h1>
+                <div class="card-content-wrapper"> <!-- Added padding around card content -->
+                    <h1 class="mdc-typography--headline4">数学公式转 SQL</h1>
             
                     <form id="math2sql_form">
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField" style="width: 100%; margin-bottom: 16px;">
+                        <div class="mdc-text-field mdc-text-field--outlined form-field-wrapper" data-mdc-auto-init="MDCTextField">
                             <input type="text" class="mdc-text-field__input" id="math_expression" name="math_expression" required>
                             <div class="mdc-notched-outline">
                                 <div class="mdc-notched-outline__leading"></div>
@@ -25,7 +26,7 @@
                                 <div class="mdc-notched-outline__trailing"></div>
                             </div>
                         </div>
-                        <div class="mdc-select mdc-select--outlined" data-mdc-auto-init="MDCSelect" id="sql_dialect" style="width: 100%; margin-bottom: 16px;">
+                        <div class="mdc-select mdc-select--outlined form-field-wrapper" data-mdc-auto-init="MDCSelect" id="sql_dialect">
                             <div class="mdc-select__anchor" role="button" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="sql-dialect-label">
                                 <span class="mdc-select__ripple"></span>
                                 <span class="mdc-notched-outline">
@@ -66,7 +67,7 @@
                                 <div class="mdc-notched-outline__trailing"></div>
                             </div>
                         </div>
-                        <div style="margin-bottom: 16px; text-align: center;">
+                        <div class="form-actions-wrapper">
                             <button class="mdc-button mdc-button--raised" onclick="convertToSQL()">
                                 <span class="mdc-button__ripple"></span>
                                 <span class="mdc-button__label">转换查询</span>
@@ -74,10 +75,10 @@
                         </div>
                     </form>
             
-                    <div id="result_sql_container" style="margin-top: 24px;">
-                        <h2 class="mdc-typography--headline6" style="margin-bottom: 8px;">生成的 SQL</h2>
-                        <pre id="result_sql" style="border: 1px solid var(--mdc-theme-on-surface, #0000001f); padding: 16px; border-radius: 4px; min-height: 100px; background-color: #f5f5f5; overflow-x: auto;">SQL 输出将在此显示...</pre>
-                        <p id="error_message" class="error-message mdc-typography--caption" style="color: var(--mdc-theme-error, #b00020); margin-top: 8px;"></p>
+                    <div id="result_sql_container">
+                        <h2 class="mdc-typography--headline6">生成的 SQL</h2>
+                        <pre id="result_sql">SQL 输出将在此显示...</pre>
+                        <p id="error_message" class="error-message mdc-typography--caption"></p>
                     </div>
                 </div> <!-- End padding div -->
             </div> <!-- End mdc-card -->


### PR DESCRIPTION
This commit implements a "Minimalist Tech Style" for the frontend, building upon the previous Material Design component structure. The new style focuses on pure white space, high-contrast color schemes (dark theme), elegant typography, a subtle grid background, and smoother, flatter component appearances.

Key changes:
- Created and linked `webapp/static/css/minimal_tech.css`.
- Moved all previous inline styles from `index.html` to this new CSS file.
- Defined a dark theme color palette with high contrast (e.g., near-black background, light text, bright teal accent).
- Applied 'Inter' font family for a modern, clean typographic feel.
- Implemented a subtle grid pattern on the body background.
- Refined Material Design Component styles (card, text fields, select, button) to be flatter, with sharper corners, and themed borders/focus states consistent with the minimalist tech aesthetic.
- Enhanced spacing and layout to increase white space and improve content focus.

All changes were made based on your specific design direction. Functionality remains consistent.