### PR TITLE
fix: Disable ripple effect on MDC select component

### DIFF
--- a/webapp/static/css/minimal_tech.css
+++ b/webapp/static/css/minimal_tech.css
@@ -203,3 +203,23 @@ p#error_message.mdc-typography--caption {
     margin-top: 12px; /* Increased from 8px */
     min-height: 1.2em; /* Ensure space even when empty */
 }
+
+/* --- Ripple Customization for MDC Select --- */
+.mdc-select__anchor {
+    overflow: hidden; /* Ensure ripple is contained */
+    position: relative; /* Ripples need a positioned ancestor */
+}
+
+/*
+.mdc-select__ripple::before,
+.mdc-select__ripple::after {
+    background-color: var(--tech-accent-color);
+    opacity: 0.1;
+}
+*/
+
+/* Fallback: Option to completely disable the ripple on the select component - NOW ACTIVE */
+.mdc-select__ripple::before,
+.mdc-select__ripple::after {
+    display: none !important;
+}


### PR DESCRIPTION
Based on your feedback, the ripple effect (click animation) on the SQL dialect selector (`.mdc-select`) has been deemed unsightly and not fitting the minimalist tech aesthetic.

This commit updates `webapp/static/css/minimal_tech.css` to completely disable the ripple effect for this component by setting `display: none !important;` on the `.mdc-select__ripple::before` and `.mdc-select__ripple::after` pseudo-elements.

The previous rules for a subtle ripple have been commented out.